### PR TITLE
CS fixes

### DIFF
--- a/Model/Acl/AclClass.php
+++ b/Model/Acl/AclClass.php
@@ -15,14 +15,14 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 class AclClass extends BaseAclClass
 {
     /**
-     * Return an AclClass for the given ACL ObjectIdentity.
+     * Returns an AclClass for the given ACL ObjectIdentity.
      *
      * If none can be found, a new one will be saved.
      *
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $objectIdentity
-     * @param \PropelPDO                                                    $con
+     * @param ObjectIdentityInterface $objectIdentity
+     * @param \PropelPDO|null         $con
      *
-     * @return \Propel\Bundle\PropelAclBundle\Model\Acl\AclClass
+     * @return AclClass
      */
     public static function fromAclObjectIdentity(ObjectIdentityInterface $objectIdentity, \PropelPDO $con = null)
     {

--- a/Model/Acl/Entry.php
+++ b/Model/Acl/Entry.php
@@ -20,13 +20,13 @@ use Symfony\Component\Security\Acl\Model\FieldEntryInterface;
 class Entry extends BaseEntry
 {
     /**
-     * Transform a given ACL entry into a Entry model.
+     * Transforms a given ACL entry into an Entry model.
      *
      * The entry will not be persisted!
      *
-     * @param \Symfony\Component\Security\Acl\Model\EntryInterface $aclEntry
+     * @param EntryInterface $aclEntry
      *
-     * @return \Propel\Bundle\PropelAclBundle\Model\Acl\Entry
+     * @return Entry
      */
     public static function fromAclEntry(EntryInterface $aclEntry)
     {
@@ -59,12 +59,12 @@ class Entry extends BaseEntry
     }
 
     /**
-     * Transform a given model entry into an ACL related Entry (ACE).
+     * Transforms a given model entry into an ACL related Entry (ACE).
      *
-     * @param \Propel\Bundle\PropelAclBundle\Model\Acl\Entry     $modelEntry
-     * @param \Symfony\Component\Security\Acl\Model\AclInterface $acl
+     * @param Entry        $modelEntry
+     * @param AclInterface $acl
      *
-     * @return \Symfony\Component\Security\Acl\Model\EntryInterface
+     * @return EntryInterface
      */
     public static function toAclEntry(Entry $modelEntry, AclInterface $acl)
     {

--- a/Model/Acl/EntryQuery.php
+++ b/Model/Acl/EntryQuery.php
@@ -16,13 +16,13 @@ use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
 class EntryQuery extends BaseEntryQuery
 {
     /**
-     * Return Entry objects filtered by an ACL related ObjectIdentity.
+     * Returns Entry objects filtered by an ACL related ObjectIdentity.
      *
      * @see find()
      *
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $objectIdentity     An ACL related ObjectIdentity.
-     * @param array                                                         $securityIdentities A list of SecurityIdentity to filter by.
-     * @param \PropelPDO                                                    $con
+     * @param ObjectIdentityInterface $objectIdentity     An ACL related ObjectIdentity.
+     * @param array                   $securityIdentities A list of SecurityIdentity to filter by.
+     * @param \PropelPDO|null         $con
      *
      * @return \PropelObjectCollection
      */

--- a/Model/Acl/ObjectIdentity.php
+++ b/Model/Acl/ObjectIdentity.php
@@ -58,11 +58,11 @@ class ObjectIdentity extends BaseObjectIdentity
     }
 
     /**
-     * Update all ancestor entries to reflect changes on this instance.
+     * Updates all ancestor entries to reflect changes on this instance.
      *
-     * @param \PropelPDO $con
+     * @param \PropelPDO $con|null
      *
-     * @return \Propel\Bundle\PropelAclBundle\Model\Acl\ObjectIdentity $this
+     * @return ObjectIdentity
      */
     protected function updateAncestorsTree(\PropelPDO $con = null)
     {

--- a/Model/Acl/ObjectIdentityQuery.php
+++ b/Model/Acl/ObjectIdentityQuery.php
@@ -15,12 +15,12 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 class ObjectIdentityQuery extends BaseObjectIdentityQuery
 {
     /**
-     * Filter by an ObjectIdentity object belonging to the given ACL related ObjectIdentity.
+     * Filters by an ObjectIdentity object belonging to the given ACL related ObjectIdentity.
      *
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $objectIdentity
-     * @param \PropelPDO                                                    $con
+     * @param ObjectIdentityInterface $objectIdentity
+     * @param \PropelPDO|null         $con
      *
-     * @return \Propel\Bundle\PropelAclBundle\Model\Acl\ObjectIdentityQuery $this
+     * @return ObjectIdentityQuery
      */
     public function filterByAclObjectIdentity(ObjectIdentityInterface $objectIdentity, \PropelPDO $con = null)
     {
@@ -38,12 +38,12 @@ class ObjectIdentityQuery extends BaseObjectIdentityQuery
     }
 
     /**
-     * Return an ObjectIdentity object belonging to the given ACL related ObjectIdentity.
+     * Returns an ObjectIdentity object belonging to the given ACL related ObjectIdentity.
      *
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $objectIdentity
-     * @param \PropelPDO                                                    $con
+     * @param ObjectIdentityInterface $objectIdentity
+     * @param \PropelPDO|null         $con
      *
-     * @return \Propel\Bundle\PropelAclBundle\Model\Acl\ObjectIdentity
+     * @return ObjectIdentity
      */
     public function findOneByAclObjectIdentity(ObjectIdentityInterface $objectIdentity, \PropelPDO $con = null)
     {
@@ -54,10 +54,10 @@ class ObjectIdentityQuery extends BaseObjectIdentityQuery
     }
 
     /**
-     * Return all children of the given object identity.
+     * Returns all children of the given object identity.
      *
-     * @param \Propel\Bundle\PropelAclBundle\Model\Acl\ObjectIdentity $objectIdentity
-     * @param \PropelPDO                                              $con
+     * @param ObjectIdentity  $objectIdentity
+     * @param \PropelPDO|null $con
      *
      * @return \PropelObjectCollection
      */
@@ -72,8 +72,8 @@ class ObjectIdentityQuery extends BaseObjectIdentityQuery
     /**
      * Return all children and grand-children of the given object identity.
      *
-     * @param \Propel\Bundle\PropelAclBundle\Model\Acl\ObjectIdentity $objectIdentity
-     * @param \PropelPDO                                              $con
+     * @param ObjectIdentity  $objectIdentity
+     * @param \PropelPDO|null $con
      *
      * @return \PropelObjectCollection
      */
@@ -91,8 +91,8 @@ class ObjectIdentityQuery extends BaseObjectIdentityQuery
     /**
      * Return all ancestors of the given object identity.
      *
-     * @param ObjectIdentity $objectIdentity
-     * @param \PropelPDO     $con
+     * @param ObjectIdentity  $objectIdentity
+     * @param \PropelPDO|null $con
      *
      * @return \PropelObjectCollection
      */

--- a/Model/Acl/SecurityIdentity.php
+++ b/Model/Acl/SecurityIdentity.php
@@ -17,11 +17,11 @@ use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
 class SecurityIdentity extends BaseSecurityIdentity
 {
     /**
-     * Transform a given mode security identity into an ACL related SecurityIdentity.
+     * Transforms a given model security identity into an ACL related SecurityIdentity.
      *
-     * @param \Propel\Bundle\PropelAclBundle\Model\Acl\SecurityIdentity $securityIdentity
+     * @param SecurityIdentity $securityIdentity
      *
-     * @return \Symfony\Component\Security\Acl\Model\SecurityIdentityInterface
+     * @return SecurityIdentityInterface
      */
     public static function toAclIdentity(SecurityIdentity $securityIdentity)
     {
@@ -45,16 +45,16 @@ class SecurityIdentity extends BaseSecurityIdentity
     }
 
     /**
-     * Transform a given ACL security identity into a SecurityIdentity model.
+     * Transforms a given ACL security identity into a SecurityIdentity model.
      *
      * If there is no model entry given, a new one will be created and saved to the database.
      *
      * @throws \InvalidArgumentException
      *
-     * @param \Symfony\Component\Security\Acl\Model\SecurityIdentityInterface $aclIdentity
-     * @param \PropelPDO                                                      $con
+     * @param SecurityIdentityInterface $aclIdentity
+     * @param \PropelPDO|null           $con
      *
-     * @return \Propel\Bundle\PropelAclBundle\Model\Acl\SecurityIdentity
+     * @return SecurityIdentity
      */
     public static function fromAclIdentity(SecurityIdentityInterface $aclIdentity, \PropelPDO $con = null)
     {

--- a/PropelAclBundle.php
+++ b/PropelAclBundle.php
@@ -12,10 +12,8 @@ namespace Propel\Bundle\PropelAclBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * PropelAclBundle.
- *
  * @author Toni Uebernickel <tuebernickel@gmail.com>
  */
-class PropelAclBundle extends Bundle
+final class PropelAclBundle extends Bundle
 {
 }

--- a/Security/Acl/AclProvider.php
+++ b/Security/Acl/AclProvider.php
@@ -28,16 +28,27 @@ use Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface;
  */
 class AclProvider implements AclProviderInterface
 {
+    /**
+     * @var PermissionGrantingStrategyInterface
+     */
     protected $permissionGrantingStrategy;
+
+    /**
+     * @var \PropelPDO|null
+     */
     protected $connection;
+
+    /**
+     * @var AclCacheInterface|null
+     */
     protected $cache;
 
     /**
      * Constructor.
      *
-     * @param \Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface $permissionGrantingStrategy
-     * @param \PropelPDO                                                                $con
-     * @param \Symfony\Component\Security\Acl\Model\AclCacheInterface                   $cache
+     * @param PermissionGrantingStrategyInterface $permissionGrantingStrategy
+     * @param \PropelPDO|null                     $connection
+     * @param AclCacheInterface|null              $cache
      */
     public function __construct(PermissionGrantingStrategyInterface $permissionGrantingStrategy, \PropelPDO $connection = null, AclCacheInterface $cache = null)
     {
@@ -47,12 +58,7 @@ class AclProvider implements AclProviderInterface
     }
 
     /**
-     * Retrieves all child object identities from the database.
-     *
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $parentObjectIdentity
-     * @param bool                                                          $directChildrenOnly
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function findChildren(ObjectIdentityInterface $parentObjectIdentity, $directChildrenOnly = false)
     {
@@ -76,14 +82,7 @@ class AclProvider implements AclProviderInterface
     }
 
     /**
-     * Returns the ACL that belongs to the given object identity.
-     *
-     * @throws \Symfony\Component\Security\Acl\Exception\AclNotFoundException
-     *
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $objectIdentity
-     * @param array                                                         $securityIdentities
-     *
-     * @return \Symfony\Component\Security\Acl\Model\AclInterface
+     * {@inheritdoc}
      */
     public function findAcl(ObjectIdentityInterface $objectIdentity, array $securityIdentities = array())
     {
@@ -136,14 +135,7 @@ class AclProvider implements AclProviderInterface
     }
 
     /**
-     * Returns the ACLs that belong to the given object identities.
-     *
-     * @throws \Symfony\Component\Security\Acl\Exception\AclNotFoundException When at least one object identity is missing its ACL.
-     *
-     * @param array $objectIdentities   an array of ObjectIdentityInterface implementations
-     * @param array $securityIdentities an array of SecurityIdentityInterface implementations
-     *
-     * @return \SplObjectStorage mapping the passed object identities to ACLs
+     * {@inheritdoc}
      */
     public function findAcls(array $objectIdentities, array $securityIdentities = array())
     {
@@ -156,15 +148,15 @@ class AclProvider implements AclProviderInterface
     }
 
     /**
-     * Create an ACL.
+     * Creates an ACL for this provider.
      *
-     * @param \PropelObjectCollection                                       $collection
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $objectIdentity
-     * @param array                                                         $loadedSecurityIdentities
-     * @param \Symfony\Component\Security\Acl\Model\AclInterface            $parentAcl
-     * @param bool                                                          $inherited
+     * @param \PropelObjectCollection $collection
+     * @param ObjectIdentityInterface $objectIdentity
+     * @param array                   $loadedSecurityIdentities
+     * @param AclInterface|null       $parentAcl
+     * @param bool                    $inherited
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\Acl
+     * @return Acl
      */
     protected function getAcl(\PropelObjectCollection $collection, ObjectIdentityInterface $objectIdentity, array $loadedSecurityIdentities = array(), AclInterface $parentAcl = null, $inherited = true)
     {

--- a/Security/Acl/AuditableAclProvider.php
+++ b/Security/Acl/AuditableAclProvider.php
@@ -19,15 +19,15 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 class AuditableAclProvider extends MutableAclProvider
 {
     /**
-     * Get an ACL for this provider.
+     * Creates an ACL for this provider.
      *
-     * @param \PropelObjectCollection                                       $collection
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $objectIdentity
-     * @param array                                                         $loadedSecurityIdentities
-     * @param \Symfony\Component\Security\Acl\Model\AclInterface            $parentAcl
-     * @param bool                                                          $inherited
+     * @param \PropelObjectCollection $collection
+     * @param ObjectIdentityInterface $objectIdentity
+     * @param array                   $loadedSecurityIdentities
+     * @param AclInterface|null       $parentAcl
+     * @param bool                    $inherited
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\AuditableAcl
+     * @return AuditableAcl
      */
     protected function getAcl(\PropelObjectCollection $collection, ObjectIdentityInterface $objectIdentity, array $loadedSecurityIdentities = array(), AclInterface $parentAcl = null, $inherited = true)
     {

--- a/Security/Acl/Domain/Acl.php
+++ b/Security/Acl/Domain/Acl.php
@@ -24,34 +24,67 @@ class Acl implements AclInterface
 {
     protected $model = 'Propel\Bundle\PropelAclBundle\Model\Acl\Entry';
 
+    /**
+     * @var Entry[]
+     */
     protected $classAces = array();
+
+    /**
+     * @var FieldEntry[]
+     */
     protected $classFieldAces = array();
+
+    /**
+     * @var Entry[]
+     */
     protected $objectAces = array();
+
+    /**
+     * @var FieldEntry[]
+     */
     protected $objectFieldAces = array();
 
+    /**
+     * @var ObjectIdentityInterface
+     */
     protected $objectIdentity;
+
+    /**
+     * @var AclInterface|null
+     */
     protected $parentAcl;
+
+    /**
+     * @var PermissionGrantingStrategyInterface
+     */
     protected $permissionGrantingStrategy;
+
+    /**
+     * @var bool
+     */
     protected $inherited;
 
+    /**
+     * @var SecurityIdentityInterface[]
+     */
     protected $loadedSecurityIdentities = array();
 
     /**
      * A list of known associated fields on this ACL.
      *
-     * @var array
+     * @var string[]
      */
     protected $fields = array();
 
     /**
      * Constructor.
      *
-     * @param \PropelObjectCollection                                                   $entries
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface             $objectIdentity
-     * @param \Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface $permissionGrantingStrategy
-     * @param array                                                                     $loadedSecurityIdentities
-     * @param \Symfony\Component\Security\Acl\Model\AclInterface                        $parentAcl
-     * @param bool                                                                      $inherited
+     * @param \PropelObjectCollection             $entries
+     * @param ObjectIdentityInterface             $objectIdentity
+     * @param PermissionGrantingStrategyInterface $permissionGrantingStrategy
+     * @param array                               $loadedSecurityIdentities
+     * @param AclInterface|null                   $parentAcl
+     * @param bool                                $inherited
      */
     public function __construct(\PropelObjectCollection $entries, ObjectIdentityInterface $objectIdentity, PermissionGrantingStrategyInterface $permissionGrantingStrategy, array $loadedSecurityIdentities = array(), AclInterface $parentAcl = null, $inherited = true)
     {
@@ -97,9 +130,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * Returns all class-based ACEs associated with this ACL.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getClassAces()
     {
@@ -107,11 +138,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * Returns all class-field-based ACEs associated with this ACL.
-     *
-     * @param string $field
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getClassFieldAces($field)
     {
@@ -119,9 +146,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * Returns all object-based ACEs associated with this ACL.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getObjectAces()
     {
@@ -129,11 +154,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * Returns all object-field-based ACEs associated with this ACL.
-     *
-     * @param string $field
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getObjectFieldAces($field)
     {
@@ -141,9 +162,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * Returns the object identity associated with this ACL.
-     *
-     * @return \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface
+     * {@inheritdoc}
      */
     public function getObjectIdentity()
     {
@@ -151,9 +170,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * Returns the parent ACL, or null if there is none.
-     *
-     * @return \Symfony\Component\Security\Acl\Model\AclInterface|null
+     * {@inheritdoc}
      */
     public function getParentAcl()
     {
@@ -161,9 +178,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * Whether this ACL is inheriting ACEs from a parent ACL.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isEntriesInheriting()
     {
@@ -171,14 +186,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * Determines whether field access is granted.
-     *
-     * @param string $field
-     * @param array  $masks
-     * @param array  $securityIdentities
-     * @param bool   $administrativeMode
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isFieldGranted($field, array $masks, array $securityIdentities, $administrativeMode = false)
     {
@@ -186,15 +194,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * Determines whether access is granted.
-     *
-     * @throws \Symfony\Component\Security\Acl\Exception\NoAceFoundException when no ACE was applicable for this request
-     *
-     * @param array $masks
-     * @param array $securityIdentities
-     * @param bool  $administrativeMode
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isGranted(array $masks, array $securityIdentities, $administrativeMode = false)
     {
@@ -202,13 +202,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * Whether the ACL has loaded ACEs for all of the passed security identities.
-     *
-     * @throws \InvalidArgumentException
-     *
-     * @param mixed $securityIdentities an implementation of SecurityIdentityInterface, or an array thereof
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isSidLoaded($securityIdentities)
     {
@@ -235,11 +229,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * String representation of object.
-     *
-     * @link http://php.net/manual/en/serializable.serialize.php
-     *
-     * @return string the string representation of the object or &null;
+     * {@inheritdoc}
      */
     public function serialize()
     {
@@ -258,13 +248,7 @@ class Acl implements AclInterface
     }
 
     /**
-     * Constructs the object.
-     *
-     * @link http://php.net/manual/en/serializable.unserialize.php
-     *
-     * @param string $serialized
-     *
-     * @return mixed the original value unserialized.
+     * {@inheritdoc}
      */
     public function unserialize($serialized)
     {
@@ -294,11 +278,11 @@ class Acl implements AclInterface
     }
 
     /**
-     * Update the internal list of associated fields on this ACL.
+     * Updates the internal list of associated fields on this ACL.
      *
      * @param string $field
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\Acl $this
+     * @return Acl
      */
     protected function updateFields($field)
     {

--- a/Security/Acl/Domain/AuditableAcl.php
+++ b/Security/Acl/Domain/AuditableAcl.php
@@ -18,11 +18,7 @@ use Symfony\Component\Security\Acl\Model\AuditableAclInterface;
 class AuditableAcl extends MutableAcl implements AuditableAclInterface
 {
     /**
-     * Updates auditing for class-based ACE.
-     *
-     * @param int  $index
-     * @param bool $auditSuccess
-     * @param bool $auditFailure
+     * {@inheritdoc}
      */
     public function updateClassAuditing($index, $auditSuccess, $auditFailure)
     {
@@ -30,12 +26,7 @@ class AuditableAcl extends MutableAcl implements AuditableAclInterface
     }
 
     /**
-     * Updates auditing for class-field-based ACE.
-     *
-     * @param int    $index
-     * @param string $field
-     * @param bool   $auditSuccess
-     * @param bool   $auditFailure
+     * {@inheritdoc}
      */
     public function updateClassFieldAuditing($index, $field, $auditSuccess, $auditFailure)
     {
@@ -44,11 +35,7 @@ class AuditableAcl extends MutableAcl implements AuditableAclInterface
     }
 
     /**
-     * Updates auditing for object-based ACE.
-     *
-     * @param int  $index
-     * @param bool $auditSuccess
-     * @param bool $auditFailure
+     * {@inheritdoc}
      */
     public function updateObjectAuditing($index, $auditSuccess, $auditFailure)
     {
@@ -56,12 +43,7 @@ class AuditableAcl extends MutableAcl implements AuditableAclInterface
     }
 
     /**
-     * Updates auditing for object-field-based ACE.
-     *
-     * @param int    $index
-     * @param string $field
-     * @param bool   $auditSuccess
-     * @param bool   $auditFailure
+     * {@inheritdoc}
      */
     public function updateObjectFieldAuditing($index, $field, $auditSuccess, $auditFailure)
     {
@@ -79,7 +61,7 @@ class AuditableAcl extends MutableAcl implements AuditableAclInterface
      * @param bool  $auditSuccess
      * @param bool  $auditFailure
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\AuditableAcl $this
+     * @return AuditableAcl
      */
     protected function updateAuditing(array &$list, $index, $auditSuccess, $auditFailure)
     {

--- a/Security/Acl/Domain/Entry.php
+++ b/Security/Acl/Domain/Entry.php
@@ -13,6 +13,7 @@ use Propel\Bundle\PropelAclBundle\Model\Acl\Entry as ModelEntry;
 use Propel\Bundle\PropelAclBundle\Model\Acl\SecurityIdentity;
 use Symfony\Component\Security\Acl\Model\AclInterface;
 use Symfony\Component\Security\Acl\Model\AuditableEntryInterface;
+use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
 
 /**
  * An ACE implementation retrieving data from a given Propel\Bundle\PropelAclBundle\Model\Acl\Entry.
@@ -25,21 +26,51 @@ use Symfony\Component\Security\Acl\Model\AuditableEntryInterface;
  */
 class Entry implements AuditableEntryInterface
 {
+    /**
+     * @var AclInterface
+     */
     protected $acl;
 
+    /**
+     * @var int
+     */
     protected $id;
+
+    /**
+     * @var SecurityIdentityInterface
+     */
     protected $securityIdentity;
+
+    /**
+     * @var int
+     */
     protected $mask;
+
+    /**
+     * @var bool
+     */
     protected $isGranting;
+
+    /**
+     * @var string
+     */
     protected $strategy;
+
+    /**
+     * @var bool
+     */
     protected $auditSuccess;
+
+    /**
+     * @var bool
+     */
     protected $auditFailure;
 
     /**
      * Constructor.
      *
-     * @param \Propel\Bundle\PropelAclBundle\Model\Acl\Entry     $entry
-     * @param \Symfony\Component\Security\Acl\Model\AclInterface $acl
+     * @param ModelEntry   $entry
+     * @param AclInterface $acl
      */
     public function __construct(ModelEntry $entry, AclInterface $acl)
     {
@@ -62,11 +93,7 @@ class Entry implements AuditableEntryInterface
     }
 
     /**
-     * String representation of object.
-     *
-     * @link http://php.net/manual/en/serializable.serialize.php
-     *
-     * @return string the string representation of the object or &null;
+     * {@inheritdoc}
      */
     public function serialize()
     {
@@ -83,13 +110,7 @@ class Entry implements AuditableEntryInterface
     }
 
     /**
-     * Constructs the object.
-     *
-     * @link http://php.net/manual/en/serializable.unserialize.php
-     *
-     * @param string $serialized
-     *
-     * @return mixed the original value unserialized.
+     * {@inheritdoc}
      */
     public function unserialize($serialized)
     {
@@ -107,9 +128,7 @@ class Entry implements AuditableEntryInterface
     }
 
     /**
-     * The ACL this ACE is associated with.
-     *
-     * @return \Symfony\Component\Security\Acl\Model\AclInterface
+     * {@inheritdoc}
      */
     public function getAcl()
     {
@@ -117,9 +136,7 @@ class Entry implements AuditableEntryInterface
     }
 
     /**
-     * The security identity associated with this ACE.
-     *
-     * @return \Symfony\Component\Security\Acl\Model\SecurityIdentityInterface
+     * {@inheritdoc}
      */
     public function getSecurityIdentity()
     {
@@ -127,9 +144,7 @@ class Entry implements AuditableEntryInterface
     }
 
     /**
-     * The primary key of this ACE.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     public function getId()
     {
@@ -137,9 +152,7 @@ class Entry implements AuditableEntryInterface
     }
 
     /**
-     * The permission mask of this ACE.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     public function getMask()
     {
@@ -147,9 +160,7 @@ class Entry implements AuditableEntryInterface
     }
 
     /**
-     * The strategy for comparing masks.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getStrategy()
     {
@@ -157,9 +168,7 @@ class Entry implements AuditableEntryInterface
     }
 
     /**
-     * Returns whether this ACE is granting, or denying.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isGranting()
     {
@@ -167,9 +176,7 @@ class Entry implements AuditableEntryInterface
     }
 
     /**
-     * Whether auditing for successful grants is turned on.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isAuditFailure()
     {
@@ -177,9 +184,7 @@ class Entry implements AuditableEntryInterface
     }
 
     /**
-     * Whether auditing for successful denies is turned on.
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function isAuditSuccess()
     {

--- a/Security/Acl/Domain/FieldEntry.php
+++ b/Security/Acl/Domain/FieldEntry.php
@@ -24,13 +24,16 @@ use Symfony\Component\Security\Acl\Model\FieldEntryInterface;
  */
 class FieldEntry extends Entry implements FieldEntryInterface
 {
+    /**
+     * @var string
+     */
     protected $field;
 
     /**
      * Constructor.
      *
-     * @param \Propel\Bundle\PropelAclBundle\Model\Acl\Entry     $entry
-     * @param \Symfony\Component\Security\Acl\Model\AclInterface $acl
+     * @param ModelEntry   $entry
+     * @param AclInterface $acl
      */
     public function __construct(ModelEntry $entry, AclInterface $acl)
     {
@@ -40,9 +43,7 @@ class FieldEntry extends Entry implements FieldEntryInterface
     }
 
     /**
-     * Returns the field used for this entry.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getField()
     {
@@ -50,11 +51,7 @@ class FieldEntry extends Entry implements FieldEntryInterface
     }
 
     /**
-     * String representation of object.
-     *
-     * @link http://php.net/manual/en/serializable.serialize.php
-     *
-     * @return string the string representation of the object or &null;
+     * {@inheritdoc}
      */
     public function serialize()
     {
@@ -72,13 +69,7 @@ class FieldEntry extends Entry implements FieldEntryInterface
     }
 
     /**
-     * Constructs the object.
-     *
-     * @link http://php.net/manual/en/serializable.unserialize.php
-     *
-     * @param string $serialized
-     *
-     * @return mixed the original value unserialized.
+     * {@inheritdoc}
      */
     public function unserialize($serialized)
     {

--- a/Security/Acl/Domain/MutableAcl.php
+++ b/Security/Acl/Domain/MutableAcl.php
@@ -37,27 +37,27 @@ class MutableAcl extends Acl implements MutableAclInterface
     /**
      * A reference to the ObjectIdentity this ACL is mapped to.
      *
-     * @var \Propel\Bundle\PropelAclBundle\Model\Acl\ObjectIdentity
+     * @var ObjectIdentity
      */
     protected $modelObjectIdentity;
 
     /**
      * A connection to be used for all changes on the ACL.
      *
-     * @var \PropelPDO
+     * @var \PropelPDO|null
      */
     protected $con;
 
     /**
      * Constructor.
      *
-     * @param \PropelObjectCollection                                                   $entries
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface             $objectIdentity
-     * @param \Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface $permissionGrantingStrategy
-     * @param array                                                                     $loadedSecurityIdentities
-     * @param \Symfony\Component\Security\Acl\Model\AclInterface                        $parentAcl
-     * @param bool                                                                      $inherited
-     * @param \PropelPDO                                                                $con
+     * @param \PropelObjectCollection             $entries
+     * @param ObjectIdentityInterface             $objectIdentity
+     * @param PermissionGrantingStrategyInterface $permissionGrantingStrategy
+     * @param array                               $loadedSecurityIdentities
+     * @param AclInterface|null                   $parentAcl
+     * @param bool                                $inherited
+     * @param \PropelPDO|null                     $con
      */
     public function __construct(\PropelObjectCollection $entries, ObjectIdentityInterface $objectIdentity, PermissionGrantingStrategyInterface $permissionGrantingStrategy, array $loadedSecurityIdentities = array(), AclInterface $parentAcl = null, $inherited = true, \PropelPDO $con = null)
     {
@@ -78,9 +78,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Returns the primary key of this ACL.
-     *
-     * @return int
+     * {@inheritdoc}
      */
     public function getId()
     {
@@ -88,9 +86,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Sets whether entries are inherited.
-     *
-     * @param bool $boolean
+     * {@inheritdoc}
      */
     public function setEntriesInheriting($boolean)
     {
@@ -98,9 +94,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Sets the parent ACL.
-     *
-     * @param \Symfony\Component\Security\Acl\Model\AclInterface|null $acl
+     * {@inheritdoc}
      */
     public function setParentAcl(AclInterface $acl = null)
     {
@@ -108,9 +102,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Deletes a class-based ACE.
-     *
-     * @param int $index
+     * {@inheritdoc}
      */
     public function deleteClassAce($index)
     {
@@ -118,10 +110,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Deletes a class-field-based ACE.
-     *
-     * @param int    $index
-     * @param string $field
+     * {@inheritdoc}
      */
     public function deleteClassFieldAce($index, $field)
     {
@@ -132,9 +121,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Deletes an object-based ACE.
-     *
-     * @param int $index
+     * {@inheritdoc}
      */
     public function deleteObjectAce($index)
     {
@@ -142,10 +129,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Deletes an object-field-based ACE.
-     *
-     * @param int    $index
-     * @param string $field
+     * {@inheritdoc}
      */
     public function deleteObjectFieldAce($index, $field)
     {
@@ -156,13 +140,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Inserts a class-based ACE.
-     *
-     * @param \Symfony\Component\Security\Acl\Model\SecurityIdentityInterface $securityIdentity
-     * @param int                                                             $mask
-     * @param int                                                             $index
-     * @param bool                                                            $granting
-     * @param string                                                          $strategy
+     * {@inheritdoc}
      */
     public function insertClassAce(SecurityIdentityInterface $securityIdentity, $mask, $index = 0, $granting = true, $strategy = null)
     {
@@ -170,14 +148,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Inserts a class-field-based ACE.
-     *
-     * @param string                                                          $field
-     * @param \Symfony\Component\Security\Acl\Model\SecurityIdentityInterface $securityIdentity
-     * @param int                                                             $mask
-     * @param int                                                             $index
-     * @param bool                                                            $granting
-     * @param string                                                          $strategy
+     * {@inheritdoc}
      */
     public function insertClassFieldAce($field, SecurityIdentityInterface $securityIdentity, $mask, $index = 0, $granting = true, $strategy = null)
     {
@@ -189,13 +160,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Inserts an object-based ACE.
-     *
-     * @param \Symfony\Component\Security\Acl\Model\SecurityIdentityInterface $securityIdentity
-     * @param int                                                             $mask
-     * @param int                                                             $index
-     * @param bool                                                            $granting
-     * @param string                                                          $strategy
+     * {@inheritdoc}
      */
     public function insertObjectAce(SecurityIdentityInterface $securityIdentity, $mask, $index = 0, $granting = true, $strategy = null)
     {
@@ -203,14 +168,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Inserts an object-field-based ACE.
-     *
-     * @param string                                                          $field
-     * @param \Symfony\Component\Security\Acl\Model\SecurityIdentityInterface $securityIdentity
-     * @param int                                                             $mask
-     * @param int                                                             $index
-     * @param bool                                                            $granting
-     * @param string                                                          $strategy
+     * {@inheritdoc}
      */
     public function insertObjectFieldAce($field, SecurityIdentityInterface $securityIdentity, $mask, $index = 0, $granting = true, $strategy = null)
     {
@@ -222,11 +180,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Updates a class-based ACE.
-     *
-     * @param int    $index
-     * @param int    $mask
-     * @param string $strategy if null the strategy should not be changed
+     * {@inheritdoc}
      */
     public function updateClassAce($index, $mask, $strategy = null)
     {
@@ -234,12 +188,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Updates a class-field-based ACE.
-     *
-     * @param int    $index
-     * @param string $field
-     * @param int    $mask
-     * @param string $strategy if null the strategy should not be changed
+     * {@inheritdoc}
      */
     public function updateClassFieldAce($index, $field, $mask, $strategy = null)
     {
@@ -250,11 +199,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Updates an object-based ACE.
-     *
-     * @param int    $index
-     * @param int    $mask
-     * @param string $strategy if null the strategy should not be changed
+     * {@inheritdoc}
      */
     public function updateObjectAce($index, $mask, $strategy = null)
     {
@@ -262,12 +207,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Updates an object-field-based ACE.
-     *
-     * @param int    $index
-     * @param string $field
-     * @param int    $mask
-     * @param string $strategy if null the strategy should not be changed
+     * {@inheritdoc}
      */
     public function updateObjectFieldAce($index, $field, $mask, $strategy = null)
     {
@@ -276,11 +216,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * String representation of object.
-     *
-     * @link http://php.net/manual/en/serializable.serialize.php
-     *
-     * @return string the string representation of the object or &null;
+     * {@inheritdoc}
      */
     public function serialize()
     {
@@ -301,13 +237,7 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Constructs the object.
-     *
-     * @link http://php.net/manual/en/serializable.unserialize.php
-     *
-     * @param string $serialized
-     *
-     * @return mixed the original value unserialized.
+     * {@inheritdoc}
      */
     public function unserialize($serialized)
     {
@@ -329,13 +259,13 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Insert a given entry into the list on the given index by shifting all others.
+     * Inserts a given entry into the list on the given index by shifting all others.
      *
-     * @param array                                                $list
-     * @param int                                                  $index
-     * @param \Propel\Bundle\PropelAclBundle\Model\Acl\Entry\Entry $entry
+     * @param array $list
+     * @param int   $index
+     * @param Entry $entry
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\MutableAcl $this
+     * @return MutableAcl
      */
     protected function insertToList(array &$list, $index, Entry $entry)
     {
@@ -355,15 +285,14 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Update a single ACE of this ACL.
+     * Updates a single ACE of this ACL.
      *
-     * @param array  $list
-     * @param int    $index
-     * @param int    $mask
-     * @param string $strategy
-     * @param string $field
+     * @param array       $list
+     * @param int         $index
+     * @param int         $mask
+     * @param string|null $strategy
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\MutableAcl $this
+     * @return MutableAcl
      */
     protected function updateAce(array &$list, $index, $mask, $strategy = null)
     {
@@ -383,14 +312,14 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Delete the ACE of the given list and index.
+     * Deletes the ACE of the given list and index.
      *
      * The list will be re-ordered to have a valid 0..x list.
      *
      * @param array $list
-     * @param $index
+     * @param int   $index
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\MutableAcl $this
+     * @return MutableAcl
      */
     protected function deleteIndex(array &$list, $index)
     {
@@ -402,14 +331,14 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Validate the index on the given list of ACEs.
+     * Validates the index on the given list of ACEs.
      *
      * @throws \OutOfBoundsException
      *
      * @param array $list
      * @param int   $index
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\MutableAcl $this
+     * @return MutableAcl
      */
     protected function isWithinBounds(array &$list, $index)
     {
@@ -422,14 +351,14 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Check the index for existence in the given list.
+     * Checks the index for existence in the given list.
      *
      * @throws \OutOfBoundsException
      *
      * @param array $list
      * @param $index
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\MutableAcl $this
+     * @return MutableAcl
      */
     protected function validateIndex(array &$list, $index)
     {
@@ -441,14 +370,14 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Validate the given field to be present.
+     * Validates the given field to be present.
      *
      * @throws \InvalidArgumentException
      *
      * @param array  $list
      * @param string $field
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\MutableAcl $this
+     * @return MutableAcl
      */
     protected function validateField(array &$list, $field)
     {
@@ -460,12 +389,12 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Order the given list to have numeric indexes from 0..x.
+     * Orders the given list to have numeric indexes from 0..x.
      *
      * @param array $list
      * @param int   $index The right boundary to which the list is valid.
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\MutableAcl $this
+     * @return MutableAcl
      */
     protected function reorderList(array &$list, $index)
     {
@@ -478,16 +407,16 @@ class MutableAcl extends Acl implements MutableAclInterface
     }
 
     /**
-     * Create a new ACL Entry.
+     * Creates a new ACL Entry.
      *
-     * @param int                                                             $mask
-     * @param int                                                             $index
-     * @param \Symfony\Component\Security\Acl\Model\SecurityIdentityInterface $securityIdentity
-     * @param string                                                          $strategy
-     * @param bool                                                            $granting
-     * @param string                                                          $field
+     * @param int                       $mask
+     * @param int                       $index
+     * @param SecurityIdentityInterface $securityIdentity
+     * @param string                    $strategy
+     * @param bool                      $granting
+     * @param string                    $field
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\Entry|\Propel\Bundle\PropelAclBundle\Security\Acl\Domain\FieldEntry
+     * @return Entry|FieldEntry
      */
     protected function createAce($mask, $index, SecurityIdentityInterface $securityIdentity, $strategy = null, $granting = true, $field = null)
     {

--- a/Security/Acl/MutableAclProvider.php
+++ b/Security/Acl/MutableAclProvider.php
@@ -36,11 +36,11 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Creates a new ACL for the given object identity.
      *
-     * @throws \Symfony\Component\Security\Acl\Exception\AclAlreadyExistsException When there already is an ACL for the given object identity.
+     * @throws AclAlreadyExistsException When there already is an ACL for the given object identity.
      *
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $objectIdentity
+     * @param ObjectIdentityInterface $objectIdentity
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\MutableAcl
+     * @return MutableAcl
      */
     public function createAcl(ObjectIdentityInterface $objectIdentity)
     {
@@ -63,16 +63,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     }
 
     /**
-     * Deletes the ACL for a given object identity.
-     *
-     * This will automatically trigger a delete for any child ACLs. If you don't
-     * want child ACLs to be deleted, you will have to set their parent ACL to null.
-     *
-     * @throws \Symfony\Component\Security\Acl\Exception\Exception
-     *
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $objectIdentity
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function deleteAcl(ObjectIdentityInterface $objectIdentity)
     {
@@ -117,22 +108,14 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
 
             return true;
         // @codeCoverageIgnoreStart
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             throw new AclException('An error occurred while deleting the ACL.', 1, $e);
         }
         // @codeCoverageIgnoreEnd
     }
 
     /**
-     * Persists any changes which were made to the ACL, or any associated access control entries.
-     *
-     * Changes to parent ACLs are not persisted.
-     *
-     * @throws \Symfony\Component\Security\Acl\Exception\Exception
-     *
-     * @param \Symfony\Component\Security\Acl\Model\MutableAclInterface $acl
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function updateAcl(MutableAclInterface $acl)
     {
@@ -197,17 +180,17 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     /**
      * Persist the given ACEs.
      *
-     * @param array                                                   $accessControlEntries
-     * @param \Propel\Bundle\PropelAclBundle\Model\Acl\ObjectIdentity $objectIdentity
-     * @param bool                                                    $object
+     * @param array          $accessControlEntries
+     * @param ObjectIdentity $objectIdentity
+     * @param bool           $object
      *
-     * @return array The IDs of the persisted ACEs.
+     * @return int[] The IDs of the persisted ACEs.
      */
     protected function persistAcl(array $accessControlEntries, ObjectIdentity $objectIdentity, $object = false)
     {
         $entries = array();
 
-        /* @var $eachAce \Symfony\Component\Security\Acl\Model\EntryInterface */
+        /* @var $eachAce EntryInterface */
         foreach ($accessControlEntries as $order => $eachAce) {
             // If the given ACE has never been persisted, create a new one.
             if (null === $entry = $this->getPersistedAce($eachAce, $objectIdentity, $object)) {
@@ -252,9 +235,11 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
      *
      * If none is given, null is returned.
      *
-     * @param \Symfony\Component\Security\Acl\Model\EntryInterface $ace
+     * @param EntryInterface $ace
+     * @param ObjectIdentity $objectIdentity
+     * @param bool           $object
      *
-     * @return \Propel\Bundle\PropelAclBundle\Model\Acl\Entry|null
+     * @return ModelEntry|null
      */
     protected function getPersistedAce(EntryInterface $ace, ObjectIdentity $objectIdentity, $object = false)
     {
@@ -291,15 +276,15 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     }
 
     /**
-     * Get an ACL for this provider.
+     * Creates an ACL for this provider.
      *
-     * @param \PropelObjectCollection                                       $collection
-     * @param \Symfony\Component\Security\Acl\Model\ObjectIdentityInterface $objectIdentity
-     * @param array                                                         $loadedSecurityIdentities
-     * @param \Symfony\Component\Security\Acl\Model\AclInterface            $parentAcl
-     * @param bool                                                          $inherited
+     * @param \PropelObjectCollection $collection
+     * @param ObjectIdentityInterface $objectIdentity
+     * @param array                   $loadedSecurityIdentities
+     * @param AclInterface|null       $parentAcl
+     * @param bool                    $inherited
      *
-     * @return \Propel\Bundle\PropelAclBundle\Security\Acl\Domain\MutableAcl
+     * @return MutableAcl
      */
     protected function getAcl(\PropelObjectCollection $collection, ObjectIdentityInterface $objectIdentity, array $loadedSecurityIdentities = array(), AclInterface $parentAcl = null, $inherited = true)
     {

--- a/Tests/Fixtures/Acl/ArrayCache.php
+++ b/Tests/Fixtures/Acl/ArrayCache.php
@@ -15,8 +15,14 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 
 class ArrayCache implements AclCacheInterface
 {
+    /**
+     * @var AclInterface[]
+     */
     public $content = array();
 
+    /**
+     * {@inheritdoc}
+     */
     public function evictFromCacheById($primaryKey)
     {
         if (isset($this->content[$primaryKey])) {
@@ -24,11 +30,17 @@ class ArrayCache implements AclCacheInterface
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function evictFromCacheByIdentity(ObjectIdentityInterface $oid)
     {
         // Propel ACL does not make use of those.
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getFromCacheById($primaryKey)
     {
         if (isset($this->content[$primaryKey])) {
@@ -38,11 +50,17 @@ class ArrayCache implements AclCacheInterface
         return;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getFromCacheByIdentity(ObjectIdentityInterface $oid)
     {
         // Propel ACL does not make use of those.
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function putInCache(AclInterface $acl)
     {
         if (null === $acl->getId()) {
@@ -52,6 +70,9 @@ class ArrayCache implements AclCacheInterface
         $this->content[$acl->getId()] = $acl;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function clearCache()
     {
         $this->content = array();

--- a/Tests/Model/Acl/AclClassTest.php
+++ b/Tests/Model/Acl/AclClassTest.php
@@ -9,7 +9,6 @@
  */
 namespace Propel\Bundle\PropelAclBundle\Tests\Model\Acl;
 
-use Criteria;
 use Propel\Bundle\PropelAclBundle\Model\Acl\AclClass;
 use Propel\Bundle\PropelAclBundle\Model\Acl\AclClassPeer;
 use Propel\Bundle\PropelAclBundle\Tests\TestCase;
@@ -28,7 +27,7 @@ class AclClassTest extends TestCase
         $this->assertInstanceOf('Propel\Bundle\PropelAclBundle\Model\Acl\AclClass', $aclClass);
         $this->assertEquals($type, $aclClass->getType());
 
-        $dbEntry = AclClassPeer::doSelectOne(new Criteria(), $this->con);
+        $dbEntry = AclClassPeer::doSelectOne(new \Criteria(), $this->con);
         $this->assertInstanceOf('Propel\Bundle\PropelAclBundle\Model\Acl\AclClass', $dbEntry);
         $this->assertEquals($type, $dbEntry->getType());
 

--- a/Tests/Model/Acl/ObjectIdentityTest.php
+++ b/Tests/Model/Acl/ObjectIdentityTest.php
@@ -9,7 +9,6 @@
  */
 namespace Propel\Bundle\PropelAclBundle\Tests\Model\Acl;
 
-use Criteria;
 use Propel\Bundle\PropelAclBundle\Model\Acl\ObjectIdentity;
 use Propel\Bundle\PropelAclBundle\Model\Acl\ObjectIdentityAncestorQuery;
 use Propel\Bundle\PropelAclBundle\Model\Acl\ObjectIdentityQuery;
@@ -31,7 +30,7 @@ class ObjectIdentityTest extends TestCase
 
         $anotherIdenity = $this->createModelObjectIdentity(2);
 
-        $ancestorEntries = ObjectIdentityAncestorQuery::create()->orderByAncestorId(Criteria::ASC)->find($this->con);
+        $ancestorEntries = ObjectIdentityAncestorQuery::create()->orderByAncestorId(\Criteria::ASC)->find($this->con);
         $this->assertCount(2, $ancestorEntries);
         $this->assertEquals($objIdenity->getId(), $ancestorEntries[0]->getAncestorId());
         $this->assertEquals($objIdenity->getId(), $ancestorEntries[0]->getObjectIdentityId());
@@ -48,7 +47,7 @@ class ObjectIdentityTest extends TestCase
 
         $entries = ObjectIdentityAncestorQuery::create()
             ->filterByObjectIdentityId($obj->getId())
-            ->orderByAncestorId(Criteria::ASC)
+            ->orderByAncestorId(\Criteria::ASC)
             ->find($this->con)
         ;
         $this->assertCount(2, $entries);
@@ -61,7 +60,7 @@ class ObjectIdentityTest extends TestCase
 
         $entries = ObjectIdentityAncestorQuery::create()
             ->filterByObjectIdentityId($obj->getId())
-            ->orderByAncestorId(Criteria::ASC)
+            ->orderByAncestorId(\Criteria::ASC)
             ->find($this->con)
         ;
         $this->assertCount(1, $entries);
@@ -82,8 +81,8 @@ class ObjectIdentityTest extends TestCase
         $obj->setObjectIdentityRelatedByParentObjectIdentityId($parent)->save($this->con);
 
         $entries = ObjectIdentityAncestorQuery::create()
-            ->orderByObjectIdentityId(Criteria::ASC)
-            ->orderByAncestorId(Criteria::ASC)
+            ->orderByObjectIdentityId(\Criteria::ASC)
+            ->orderByAncestorId(\Criteria::ASC)
             ->find($this->con)
         ;
         $this->assertCount(6, $entries);
@@ -135,8 +134,8 @@ class ObjectIdentityTest extends TestCase
 
         // Verify "before"
         $entries = ObjectIdentityAncestorQuery::create()
-            ->orderByObjectIdentityId(Criteria::ASC)
-            ->orderByAncestorId(Criteria::ASC)
+            ->orderByObjectIdentityId(\Criteria::ASC)
+            ->orderByAncestorId(\Criteria::ASC)
             ->find($this->con)
         ;
         $this->assertCount(9, $entries);
@@ -172,8 +171,8 @@ class ObjectIdentityTest extends TestCase
         $obj->setObjectIdentityRelatedByParentObjectIdentityId($parent)->save($this->con);
 
         $entries = ObjectIdentityAncestorQuery::create()
-            ->orderByObjectIdentityId(Criteria::ASC)
-            ->orderByAncestorId(Criteria::ASC)
+            ->orderByObjectIdentityId(\Criteria::ASC)
+            ->orderByAncestorId(\Criteria::ASC)
             ->find($this->con)
         ;
         $this->assertCount(15, $entries);
@@ -227,8 +226,8 @@ class ObjectIdentityTest extends TestCase
         $obj->setObjectIdentityRelatedByParentObjectIdentityId(null)->save($this->con);
 
         $entries = ObjectIdentityAncestorQuery::create()
-            ->orderByObjectIdentityId(Criteria::ASC)
-            ->orderByAncestorId(Criteria::ASC)
+            ->orderByObjectIdentityId(\Criteria::ASC)
+            ->orderByAncestorId(\Criteria::ASC)
             ->find($this->con)
         ;
         $this->assertCount(9, $entries);
@@ -290,7 +289,7 @@ class ObjectIdentityTest extends TestCase
             ->save($this->con)
         ;
 
-        $entries = ObjectIdentityQuery::create()->orderByParentObjectIdentityId(Criteria::ASC)->find($this->con);
+        $entries = ObjectIdentityQuery::create()->orderByParentObjectIdentityId(\Criteria::ASC)->find($this->con);
 
         $this->assertCount(2, $entries);
         $this->assertNull($entries[0]->getParentObjectIdentityId());

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -16,6 +16,7 @@ use Propel\Bundle\PropelAclBundle\Security\Acl\MutableAclProvider;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Acl\Domain\PermissionGrantingStrategy;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
+use Symfony\Component\Security\Acl\Model\AclCacheInterface;
 use Symfony\Component\Security\Core\Role\Role;
 
 /**
@@ -25,35 +26,33 @@ use Symfony\Component\Security\Core\Role\Role;
  */
 abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
-    protected $con = null;
-    protected $cache = null;
+    /**
+     * @var \PropelPDO|null
+     */
+    protected $con;
 
-    public static function setUpBeforeClass()
-    {
-        if (!class_exists('Propel')) {
-            self::markTestSkipped('Propel is not available.');
-        }
-    }
+    /**
+     * @var AclCacheInterface|null
+     */
+    protected $cache;
 
     public function setUp()
     {
-        parent::setUp();
-
         $schema = file_get_contents(__DIR__.'/../Resources/config/propel/acl_schema.xml');
 
         $builder = new \PropelQuickBuilder();
         $builder->setSchema($schema);
+        $builder->setClassTargets(array());
+
         if (!class_exists('Propel\Bundle\PropelAclBundle\Model\Acl\map\AclClassTableMap')) {
             $builder->setClassTargets(array('tablemap', 'peer', 'object', 'query'));
-        } else {
-            $builder->setClassTargets(array());
         }
 
         $this->con = $builder->build();
     }
 
     /**
-     * @return \Propel\Bundle\PropelAclBundle\Model\Acl\ObjectIdentity
+     * @return ModelObjectIdentity
      */
     protected function createModelObjectIdentity($identifier)
     {


### PR DESCRIPTION
- add missing type hints on members
- fix type hints on members and methods
- use `{@inheritdoc}` where applicable
- simplify FQCN where applicable
